### PR TITLE
Do not cache timestamp.  This avoids long-running processes causing aws ...

### DIFF
--- a/lib/Net/Amazon/EC2.pm
+++ b/lib/Net/Amazon/EC2.pm
@@ -155,20 +155,6 @@ has 'signature_version'	=> ( is => 'ro', isa => 'Int', required => 1, default =>
 has 'version'			=> ( is => 'ro', isa => 'Str', required => 1, default => '2011-01-01' );
 has 'region'			=> ( is => 'ro', isa => 'Str', required => 1, default => 'us-east-1' );
 has 'ssl'				=> ( is => 'ro', isa => 'Bool', required => 1, default => 0 );
-has 'timestamp'			=> ( 
-	is			=> 'ro', 
-	isa			=> 'Str', 
-	required	=> 1, 
-	lazy		=> 1,
-        clearer		=> '_clear_timestamp',
-	default		=> sub { 
-		my $ts = time2isoz(); 
-		chop($ts); 
-		$ts .= '.000Z'; 
-		$ts =~ s/\s+/T/g; 
-		return $ts; 
-	} 
-);
 has 'base_url'			=> ( 
 	is			=> 'ro', 
 	isa			=> 'Str', 
@@ -178,6 +164,14 @@ has 'base_url'			=> (
 		return 'http' . ($_[0]->ssl ? 's' : '') . '://' . $_[0]->region . '.ec2.amazonaws.com';
 	}
 );
+
+sub timestamp {
+	my $ts = time2isoz();
+	chop($ts);
+	$ts .= '.000Z';
+	$ts =~ s/\s+/T/g;
+	return $ts;
+};
 
 sub _sign {
 	my $self						= shift;


### PR DESCRIPTION
...to return 'Request has expired' errors
