### PR TITLE
use Any::Moose

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -14,7 +14,7 @@ requires		'HTTP::Date'		=> 0;
 requires		'URI'				=> 0;
 requires		'Params::Validate'	=> 0;
 requires		'XML::Simple'		=> 2.18;
-requires        'Moose'             => 0.38;
+requires        'Any::Moose'        => 0.18;
 build_requires  'Test::More'        => 0;
 
 no_index;

--- a/lib/Net/Amazon/EC2.pm
+++ b/lib/Net/Amazon/EC2.pm
@@ -1,5 +1,5 @@
 package Net::Amazon::EC2;
-use Moose;
+use Any::Moose;
 
 use strict;
 use vars qw($VERSION);
@@ -4080,7 +4080,7 @@ sub unmonitor_instances {
 	}
 }
 
-no Moose;
+no Any::Moose;
 1;
 
 __END__

--- a/lib/Net/Amazon/EC2/Attachment.pm
+++ b/lib/Net/Amazon/EC2/Attachment.pm
@@ -1,5 +1,5 @@
 package Net::Amazon::EC2::Attachment;
-use Moose;
+use Any::Moose;
 
 =head1 NAME
 
@@ -61,5 +61,5 @@ under the same terms as Perl itself.
 
 =cut
 
-no Moose;
+no Any::Moose;
 1;

--- a/lib/Net/Amazon/EC2/AvailabilityZone.pm
+++ b/lib/Net/Amazon/EC2/AvailabilityZone.pm
@@ -1,5 +1,5 @@
 package Net::Amazon::EC2::AvailabilityZone;
-use Moose;
+use Any::Moose;
 
 =head1 NAME
 
@@ -51,5 +51,5 @@ under the same terms as Perl itself.
 
 =cut
 
-no Moose;
+no Any::Moose;
 1;

--- a/lib/Net/Amazon/EC2/AvailabilityZoneMessage.pm
+++ b/lib/Net/Amazon/EC2/AvailabilityZoneMessage.pm
@@ -1,5 +1,5 @@
 package Net::Amazon::EC2::AvailabilityZoneMessage;
-use Moose;
+use Any::Moose;
 
 =head1 NAME
 
@@ -36,5 +36,5 @@ under the same terms as Perl itself.
 
 =cut
 
-no Moose;
+no Any::Moose;
 1;

--- a/lib/Net/Amazon/EC2/BlockDeviceMapping.pm
+++ b/lib/Net/Amazon/EC2/BlockDeviceMapping.pm
@@ -1,6 +1,6 @@
 package Net::Amazon::EC2::BlockDeviceMapping;
 use strict;
-use Moose;
+use Any::Moose;
 
 =head1 NAME
 
@@ -52,5 +52,5 @@ under the same terms as Perl itself.
 
 =cut
 
-no Moose;
+no Any::Moose;
 1;

--- a/lib/Net/Amazon/EC2/BundleInstanceResponse.pm
+++ b/lib/Net/Amazon/EC2/BundleInstanceResponse.pm
@@ -1,5 +1,5 @@
 package Net::Amazon::EC2::BundleInstanceResponse;
-use Moose;
+use Any::Moose;
 
 =head1 NAME
 
@@ -96,5 +96,5 @@ under the same terms as Perl itself.
 
 =cut
 
-no Moose;
+no Any::Moose;
 1;

--- a/lib/Net/Amazon/EC2/ConfirmProductInstanceResponse.pm
+++ b/lib/Net/Amazon/EC2/ConfirmProductInstanceResponse.pm
@@ -1,6 +1,6 @@
 package Net::Amazon::EC2::ConfirmProductInstanceResponse;
 use strict;
-use Moose;
+use Any::Moose;
 
 =head1 NAME
 
@@ -44,5 +44,5 @@ under the same terms as Perl itself.
 
 =cut
 
-no Moose;
+no Any::Moose;
 1;

--- a/lib/Net/Amazon/EC2/ConsoleOutput.pm
+++ b/lib/Net/Amazon/EC2/ConsoleOutput.pm
@@ -1,5 +1,5 @@
 package Net::Amazon::EC2::ConsoleOutput;
-use Moose;
+use Any::Moose;
 
 =head1 NAME
 
@@ -46,5 +46,5 @@ under the same terms as Perl itself.
 
 =cut
 
-no Moose;
+no Any::Moose;
 1;

--- a/lib/Net/Amazon/EC2/CreateVolumePermission.pm
+++ b/lib/Net/Amazon/EC2/CreateVolumePermission.pm
@@ -1,5 +1,5 @@
 package Net::Amazon::EC2::CreateVolumePermission;
-use Moose;
+use Any::Moose;
 
 =head1 NAME
 
@@ -41,5 +41,5 @@ under the same terms as Perl itself.
 
 =cut
 
-no Moose;
+no Any::Moose;
 1;

--- a/lib/Net/Amazon/EC2/DescribeAddress.pm
+++ b/lib/Net/Amazon/EC2/DescribeAddress.pm
@@ -1,5 +1,5 @@
 package Net::Amazon::EC2::DescribeAddress;
-use Moose;
+use Any::Moose;
 
 =head1 NAME
 
@@ -41,5 +41,5 @@ under the same terms as Perl itself.
 
 =cut
 
-no Moose;
+no Any::Moose;
 1;

--- a/lib/Net/Amazon/EC2/DescribeImageAttribute.pm
+++ b/lib/Net/Amazon/EC2/DescribeImageAttribute.pm
@@ -1,5 +1,5 @@
 package Net::Amazon::EC2::DescribeImageAttribute;
-use Moose;
+use Any::Moose;
 
 =head1 NAME
 
@@ -82,5 +82,5 @@ under the same terms as Perl itself.
 
 =cut
 
-no Moose;
+no Any::Moose;
 1;

--- a/lib/Net/Amazon/EC2/DescribeImagesResponse.pm
+++ b/lib/Net/Amazon/EC2/DescribeImagesResponse.pm
@@ -1,5 +1,5 @@
 package Net::Amazon::EC2::DescribeImagesResponse;
-use Moose;
+use Any::Moose;
 
 =head1 NAME
 
@@ -139,5 +139,5 @@ under the same terms as Perl itself.
 
 =cut
 
-no Moose;
+no Any::Moose;
 1;

--- a/lib/Net/Amazon/EC2/DescribeInstanceAttributeResponse.pm
+++ b/lib/Net/Amazon/EC2/DescribeInstanceAttributeResponse.pm
@@ -1,5 +1,5 @@
 package Net::Amazon::EC2::DescribeInstanceAttributeResponse;
-use Moose;
+use Any::Moose;
 
 =head1 NAME
 
@@ -84,5 +84,5 @@ under the same terms as Perl itself.
 
 =cut
 
-no Moose;
+no Any::Moose;
 1;

--- a/lib/Net/Amazon/EC2/DescribeKeyPairsResponse.pm
+++ b/lib/Net/Amazon/EC2/DescribeKeyPairsResponse.pm
@@ -1,6 +1,6 @@
 package Net::Amazon::EC2::DescribeKeyPairsResponse;
 use strict;
-use Moose;
+use Any::Moose;
 
 =head1 NAME
 
@@ -42,5 +42,5 @@ under the same terms as Perl itself.
 
 =cut
 
-no Moose;
+no Any::Moose;
 1;

--- a/lib/Net/Amazon/EC2/DescribeTags.pm
+++ b/lib/Net/Amazon/EC2/DescribeTags.pm
@@ -1,5 +1,5 @@
 package Net::Amazon::EC2::DescribeTags;
-use Moose;
+use Any::Moose;
 
 =head1 NAME
 
@@ -55,6 +55,6 @@ under the same terms as Perl itself.
 
 =cut
 
-no Moose;
+no Any::Moose;
 1;
 

--- a/lib/Net/Amazon/EC2/EbsBlockDevice.pm
+++ b/lib/Net/Amazon/EC2/EbsBlockDevice.pm
@@ -1,6 +1,6 @@
 package Net::Amazon::EC2::EbsBlockDevice;
 use strict;
-use Moose;
+use Any::Moose;
 
 =head1 NAME
 
@@ -47,5 +47,5 @@ under the same terms as Perl itself.
 
 =cut
 
-no Moose;
+no Any::Moose;
 1;

--- a/lib/Net/Amazon/EC2/EbsInstanceBlockDeviceMapping.pm
+++ b/lib/Net/Amazon/EC2/EbsInstanceBlockDeviceMapping.pm
@@ -1,6 +1,6 @@
 package Net::Amazon::EC2::EbsInstanceBlockDeviceMapping;
 use strict;
-use Moose;
+use Any::Moose;
 
 =head1 NAME
 
@@ -52,5 +52,5 @@ under the same terms as Perl itself.
 
 =cut
 
-no Moose;
+no Any::Moose;
 1;

--- a/lib/Net/Amazon/EC2/Error.pm
+++ b/lib/Net/Amazon/EC2/Error.pm
@@ -1,5 +1,5 @@
 package Net::Amazon::EC2::Error;
-use Moose;
+use Any::Moose;
 
 =head1 NAME
 
@@ -41,5 +41,5 @@ under the same terms as Perl itself.
 
 =cut
 
-no Moose;
+no Any::Moose;
 1;

--- a/lib/Net/Amazon/EC2/Errors.pm
+++ b/lib/Net/Amazon/EC2/Errors.pm
@@ -1,5 +1,5 @@
 package Net::Amazon::EC2::Errors;
-use Moose;
+use Any::Moose;
 
 =head1 NAME
 
@@ -46,5 +46,5 @@ under the same terms as Perl itself.
 
 =cut
 
-no Moose;
+no Any::Moose;
 1;

--- a/lib/Net/Amazon/EC2/GroupSet.pm
+++ b/lib/Net/Amazon/EC2/GroupSet.pm
@@ -1,5 +1,5 @@
 package Net::Amazon::EC2::GroupSet;
-use Moose;
+use Any::Moose;
 
 =head1 NAME
 
@@ -37,5 +37,5 @@ under the same terms as Perl itself.
 
 =cut
 
-no Moose;
+no Any::Moose;
 1;

--- a/lib/Net/Amazon/EC2/InstanceBlockDeviceMapping.pm
+++ b/lib/Net/Amazon/EC2/InstanceBlockDeviceMapping.pm
@@ -1,6 +1,6 @@
 package Net::Amazon::EC2::InstanceBlockDeviceMapping;
 use strict;
-use Moose;
+use Any::Moose;
 
 =head1 NAME
 
@@ -52,5 +52,5 @@ under the same terms as Perl itself.
 
 =cut
 
-no Moose;
+no Any::Moose;
 1;

--- a/lib/Net/Amazon/EC2/InstancePassword.pm
+++ b/lib/Net/Amazon/EC2/InstancePassword.pm
@@ -1,5 +1,5 @@
 package Net::Amazon::EC2::InstancePassword;
-use Moose;
+use Any::Moose;
 
 =head1 NAME
 
@@ -46,5 +46,5 @@ under the same terms as Perl itself.
 
 =cut
 
-no Moose;
+no Any::Moose;
 1;

--- a/lib/Net/Amazon/EC2/InstanceState.pm
+++ b/lib/Net/Amazon/EC2/InstanceState.pm
@@ -1,5 +1,5 @@
 package Net::Amazon::EC2::InstanceState;
-use Moose;
+use Any::Moose;
 
 =head1 NAME
 
@@ -73,5 +73,5 @@ under the same terms as Perl itself.
 
 =cut
 
-no Moose;
+no Any::Moose;
 1;

--- a/lib/Net/Amazon/EC2/InstanceStateChange.pm
+++ b/lib/Net/Amazon/EC2/InstanceStateChange.pm
@@ -1,5 +1,5 @@
 package Net::Amazon::EC2::InstanceStateChange;
-use Moose;
+use Any::Moose;
 
 =head1 NAME
 
@@ -46,5 +46,5 @@ under the same terms as Perl itself.
 
 =cut
 
-no Moose;
+no Any::Moose;
 1;

--- a/lib/Net/Amazon/EC2/IpPermission.pm
+++ b/lib/Net/Amazon/EC2/IpPermission.pm
@@ -1,5 +1,5 @@
 package Net::Amazon::EC2::IpPermission;
-use Moose;
+use Any::Moose;
 
 =head1 NAME
 
@@ -76,5 +76,5 @@ under the same terms as Perl itself.
 
 =cut
 
-no Moose;
+no Any::Moose;
 1;

--- a/lib/Net/Amazon/EC2/IpRange.pm
+++ b/lib/Net/Amazon/EC2/IpRange.pm
@@ -1,5 +1,5 @@
 package Net::Amazon::EC2::IpRange;
-use Moose;
+use Any::Moose;
 
 =head1 NAME
 
@@ -36,5 +36,5 @@ under the same terms as Perl itself.
 
 =cut
 
-no Moose;
+no Any::Moose;
 1;

--- a/lib/Net/Amazon/EC2/KeyPair.pm
+++ b/lib/Net/Amazon/EC2/KeyPair.pm
@@ -1,5 +1,5 @@
 package Net::Amazon::EC2::KeyPair;
-use Moose;
+use Any::Moose;
 
 =head1 NAME
 
@@ -38,5 +38,5 @@ under the same terms as Perl itself.
 
 =cut
 
-no Moose;
+no Any::Moose;
 1;

--- a/lib/Net/Amazon/EC2/LaunchPermission.pm
+++ b/lib/Net/Amazon/EC2/LaunchPermission.pm
@@ -1,5 +1,5 @@
 package Net::Amazon::EC2::LaunchPermission;
-use Moose;
+use Any::Moose;
 
 =head1 NAME
 
@@ -42,5 +42,5 @@ under the same terms as Perl itself.
 
 =cut
 
-no Moose;
+no Any::Moose;
 1;

--- a/lib/Net/Amazon/EC2/LaunchPermissionOperation.pm
+++ b/lib/Net/Amazon/EC2/LaunchPermissionOperation.pm
@@ -1,6 +1,6 @@
 package Net::Amazon::EC2::LaunchPermissionOperation;
 use strict;
-use Moose;
+use Any::Moose;
 
 =head1 NAME
 
@@ -42,5 +42,5 @@ under the same terms as Perl itself.
 
 =cut
 
-no Moose;
+no Any::Moose;
 1;

--- a/lib/Net/Amazon/EC2/MonitoredInstance.pm
+++ b/lib/Net/Amazon/EC2/MonitoredInstance.pm
@@ -1,5 +1,5 @@
 package Net::Amazon::EC2::MonitoredInstance;
-use Moose;
+use Any::Moose;
 
 =head1 NAME
 
@@ -41,5 +41,5 @@ under the same terms as Perl itself.
 
 =cut
 
-no Moose;
+no Any::Moose;
 1;

--- a/lib/Net/Amazon/EC2/PlacementResponse.pm
+++ b/lib/Net/Amazon/EC2/PlacementResponse.pm
@@ -1,6 +1,6 @@
 package Net::Amazon::EC2::PlacementResponse;
 use strict;
-use Moose;
+use Any::Moose;
 
 =head1 NAME
 
@@ -37,5 +37,5 @@ under the same terms as Perl itself.
 
 =cut
 
-no Moose;
+no Any::Moose;
 1;

--- a/lib/Net/Amazon/EC2/ProductCode.pm
+++ b/lib/Net/Amazon/EC2/ProductCode.pm
@@ -1,5 +1,5 @@
 package Net::Amazon::EC2::ProductCode;
-use Moose;
+use Any::Moose;
 
 =head1 NAME
 
@@ -37,5 +37,5 @@ under the same terms as Perl itself.
 
 =cut
 
-no Moose;
+no Any::Moose;
 1;

--- a/lib/Net/Amazon/EC2/ProductInstanceResponse.pm
+++ b/lib/Net/Amazon/EC2/ProductInstanceResponse.pm
@@ -1,6 +1,6 @@
 package Net::Amazon::EC2::ProductInstanceResponse;
 use strict;
-use Moose;
+use Any::Moose;
 
 =head1 NAME
 
@@ -47,5 +47,5 @@ under the same terms as Perl itself.
 
 =cut
 
-no Moose;
+no Any::Moose;
 1;

--- a/lib/Net/Amazon/EC2/Region.pm
+++ b/lib/Net/Amazon/EC2/Region.pm
@@ -1,5 +1,5 @@
 package Net::Amazon::EC2::Region;
-use Moose;
+use Any::Moose;
 
 =head1 NAME
 
@@ -41,5 +41,5 @@ under the same terms as Perl itself.
 
 =cut
 
-no Moose;
+no Any::Moose;
 1;

--- a/lib/Net/Amazon/EC2/ReservationInfo.pm
+++ b/lib/Net/Amazon/EC2/ReservationInfo.pm
@@ -1,5 +1,5 @@
 package Net::Amazon::EC2::ReservationInfo;
-use Moose;
+use Any::Moose;
 
 =head1 NAME
 
@@ -66,5 +66,5 @@ under the same terms as Perl itself.
 
 =cut
 
-no Moose;
+no Any::Moose;
 1;

--- a/lib/Net/Amazon/EC2/ReservedInstance.pm
+++ b/lib/Net/Amazon/EC2/ReservedInstance.pm
@@ -1,5 +1,5 @@
 package Net::Amazon::EC2::ReservedInstance;
-use Moose;
+use Any::Moose;
 
 =head1 NAME
 
@@ -81,5 +81,5 @@ under the same terms as Perl itself.
 
 =cut
 
-no Moose;
+no Any::Moose;
 1;

--- a/lib/Net/Amazon/EC2/ReservedInstanceOffering.pm
+++ b/lib/Net/Amazon/EC2/ReservedInstanceOffering.pm
@@ -1,5 +1,5 @@
 package Net::Amazon::EC2::ReservedInstanceOffering;
-use Moose;
+use Any::Moose;
 
 =head1 NAME
 
@@ -66,5 +66,5 @@ under the same terms as Perl itself.
 
 =cut
 
-no Moose;
+no Any::Moose;
 1;

--- a/lib/Net/Amazon/EC2/RunningInstances.pm
+++ b/lib/Net/Amazon/EC2/RunningInstances.pm
@@ -1,5 +1,5 @@
 package Net::Amazon::EC2::RunningInstances;
-use Moose;
+use Any::Moose;
 
 =head1 NAME
 
@@ -194,5 +194,5 @@ under the same terms as Perl itself.
 
 =cut
 
-no Moose;
+no Any::Moose;
 1;

--- a/lib/Net/Amazon/EC2/SecurityGroup.pm
+++ b/lib/Net/Amazon/EC2/SecurityGroup.pm
@@ -1,5 +1,5 @@
 package Net::Amazon::EC2::SecurityGroup;
-use Moose;
+use Any::Moose;
 
 =head1 NAME
 
@@ -56,5 +56,5 @@ under the same terms as Perl itself.
 
 =cut
 
-no Moose;
+no Any::Moose;
 1;

--- a/lib/Net/Amazon/EC2/Snapshot.pm
+++ b/lib/Net/Amazon/EC2/Snapshot.pm
@@ -1,5 +1,5 @@
 package Net::Amazon::EC2::Snapshot;
-use Moose;
+use Any::Moose;
 
 =head1 NAME
 
@@ -76,5 +76,5 @@ under the same terms as Perl itself.
 
 =cut
 
-no Moose;
+no Any::Moose;
 1;

--- a/lib/Net/Amazon/EC2/SnapshotAttribute.pm
+++ b/lib/Net/Amazon/EC2/SnapshotAttribute.pm
@@ -1,5 +1,5 @@
 package Net::Amazon::EC2::SnapshotAttribute;
-use Moose;
+use Any::Moose;
 
 =head1 NAME
 
@@ -41,5 +41,5 @@ under the same terms as Perl itself.
 
 =cut
 
-no Moose;
+no Any::Moose;
 1;

--- a/lib/Net/Amazon/EC2/StateReason.pm
+++ b/lib/Net/Amazon/EC2/StateReason.pm
@@ -1,5 +1,5 @@
 package Net::Amazon::EC2::StateReason;
-use Moose;
+use Any::Moose;
 
 =head1 NAME
 
@@ -41,5 +41,5 @@ under the same terms as Perl itself.
 
 =cut
 
-no Moose;
+no Any::Moose;
 1;

--- a/lib/Net/Amazon/EC2/TagSet.pm
+++ b/lib/Net/Amazon/EC2/TagSet.pm
@@ -1,5 +1,5 @@
 package Net::Amazon::EC2::TagSet;
-use Moose;
+use Any::Moose;
 
 =head1 NAME
 
@@ -41,6 +41,6 @@ under the same terms as Perl itself.
 
 =cut
 
-no Moose;
+no Any::Moose;
 1;
 

--- a/lib/Net/Amazon/EC2/UserData.pm
+++ b/lib/Net/Amazon/EC2/UserData.pm
@@ -1,6 +1,6 @@
 package Net::Amazon::EC2::UserData;
 use strict;
-use Moose;
+use Any::Moose;
 
 =head1 NAME
 
@@ -37,5 +37,5 @@ under the same terms as Perl itself.
 
 =cut
 
-no Moose;
+no Any::Moose;
 1;

--- a/lib/Net/Amazon/EC2/UserIdGroupPair.pm
+++ b/lib/Net/Amazon/EC2/UserIdGroupPair.pm
@@ -1,5 +1,5 @@
 package Net::Amazon::EC2::UserIdGroupPair;
-use Moose;
+use Any::Moose;
 
 =head1 NAME
 
@@ -41,5 +41,5 @@ under the same terms as Perl itself.
 
 =cut
 
-no Moose;
+no Any::Moose;
 1;

--- a/lib/Net/Amazon/EC2/Volume.pm
+++ b/lib/Net/Amazon/EC2/Volume.pm
@@ -1,5 +1,5 @@
 package Net::Amazon::EC2::Volume;
-use Moose;
+use Any::Moose;
 
 =head1 NAME
 
@@ -66,5 +66,5 @@ under the same terms as Perl itself.
 
 =cut
 
-no Moose;
+no Any::Moose;
 1;


### PR DESCRIPTION
Any::Moose provides significantly smaller memory footprint, which is useful if you want to control other ec2 instances on a micro instance.
