### PR TITLE
group_id appears to be optional as of this morning in the RunInstances result set.

### DIFF
--- a/lib/Net/Amazon/EC2/GroupSet.pm
+++ b/lib/Net/Amazon/EC2/GroupSet.pm
@@ -19,7 +19,7 @@ The ID of the group.
 
 =cut
 
-has 'group_id'  => ( is => 'ro', isa => 'Str', required => 1 );
+has 'group_id'  => ( is => 'ro', isa => 'Maybe[Str]', required => 1 );
 has 'group_name' => ( is => 'ro', isa => 'Str', required => 1 );
 
 __PACKAGE__->meta->make_immutable();


### PR DESCRIPTION
Dumped the xml we get back from AWS and the groupId tags/values are not returned anymore in the group set.

This blows Net::Amazon::EC2 with the following error:

Attribute (group_id) does not pass the type constraint because: Validation failed for 'Str' with value undef at constructor Net::Amazon::EC2::GroupSet::new (defined at /usr/share/perl5/Net/Amazon/EC2/GroupSet.pm line 25) line 34
    Net::Amazon::EC2::GroupSet::new('Net::Amazon::EC2::GroupSet', 'group_id', undef, 'group_name', 'default') called at /usr/share/perl5/Net/Amazon/EC2.pm line 3779

(line numbers probably from an earlier version - newest version did the same thing)

There is a chance more detail will show up in this post: https://forums.aws.amazon.com/thread.jspa?threadID=109633&tstart=0 however Amazon sometimes just ignores such things.
