### PR TITLE
run_instance tweaks

### DIFF
--- a/lib/Net/Amazon/EC2.pm
+++ b/lib/Net/Amazon/EC2.pm
@@ -3602,6 +3602,10 @@ The keypair name to associate this instance with.  If omitted, will use your def
 
 An scalar or array ref. Will associate this instance with the group names passed in.  If omitted, will be associated with the default security group.
 
+=item SecurityGroupId (optional)
+
+An scalar or array ref. Will associate this instance with the group ids passed in.  If omitted, will be associated with the default security group.
+
 =item AdditionalInfo (optional)
 
 Specifies additional information to make available to the instance(s).
@@ -3718,6 +3722,10 @@ Specifies the idempotent instance id.
 
 Whether the instance is optimized for EBS I/O.
 
+=item PrivateIpAddress (optional)
+
+Specifies the private IP address to use when launching an Amazon VPC instance.
+
 =back
 
 Returns a Net::Amazon::EC2::ReservationInfo object
@@ -3732,6 +3740,7 @@ sub run_instances {
 		MaxCount										=> { type => SCALAR },
 		KeyName											=> { type => SCALAR, optional => 1 },
 		SecurityGroup									=> { type => SCALAR | ARRAYREF, optional => 1 },
+		SecurityGroupId									=> { type => SCALAR | ARRAYREF, optional => 1 },
 		AdditionalInfo									=> { type => SCALAR, optional => 1 },
 		UserData										=> { type => SCALAR, optional => 1 },
 		InstanceType									=> { type => SCALAR, optional => 1 },
@@ -3750,7 +3759,8 @@ sub run_instances {
 		DisableApiTermination							=> { type => SCALAR, optional => 1 },
 		InstanceInitiatedShutdownBehavior				=> { type => SCALAR, optional => 1 },
 		ClientToken										=> { type => SCALAR, optional => 1 },
-		EbsOptimized										=> { type => SCALAR, optional => 1 },
+		EbsOptimized									=> { type => SCALAR, optional => 1 },
+		PrivateIpAddress								=> { type => SCALAR, optional => 1 },
 	});
 	
 	# If we have a array ref of instances lets split them out into their SecurityGroup.n format
@@ -3759,6 +3769,16 @@ sub run_instances {
 		my $count			= 1;
 		foreach my $security_group (@{$security_groups}) {
 			$args{"SecurityGroup." . $count} = $security_group;
+			$count++;
+		}
+	}
+
+	# If we have a array ref of instances lets split them out into their SecurityGroupId.n format
+	if (ref ($args{SecurityGroupId}) eq 'ARRAY') {
+		my $security_groups	= delete $args{SecurityGroupId};
+		my $count			= 1;
+		foreach my $security_group (@{$security_groups}) {
+			$args{"SecurityGroupId." . $count} = $security_group;
 			$count++;
 		}
 	}


### PR DESCRIPTION
We need to specify vpc as well as security groups when firing up instances.  Amazon doesn't support using security group names in those cases; you have to use the SecurityGroupId.  I added support for that edge condition.

While I was in there, added support for specifying a PrivateIpAddress as well.

Output of make test:

[paden@d0 net-amazon-ec2]$ make test
PERL_DL_NONLAZY=1 /usr/bin/perl "-MExtUtils::Command::MM" "-e" "test_harness(0, 'inc', 'blib/lib', 'blib/arch')" t/00_use.t t/01_init.t t/02_live.t t/03_failing_calls.t
t/00_use.t ............ ok  
t/01_init.t ........... ok  
t/02_live.t ........... ok  
t/03_failing_calls.t .. 1/5 $VAR1 = {
          'RequestID' => 'N/A',
          'Errors' => [
                      {
                        'Error' => {
                                   'Code' => 'HTTP POST FAILURE',
                                   'Message' => '500 Can\'t connect to localhost:22718 (Connection refused)'
                                 }
                      }
                    ]
        };

t/03_failing_calls.t .. ok  
All tests successful.
Files=4, Tests=76, 17 wallclock secs ( 0.04 usr  0.04 sys +  7.29 cusr  0.60 csys =  7.97 CPU)
Result: PASS
