### PR TITLE
Added optional parameter 'AddressingType' to the 'runInstance' method.

### DIFF
--- a/lib/Net/Amazon/EC2.pm
+++ b/lib/Net/Amazon/EC2.pm
@@ -3741,6 +3741,7 @@ sub run_instances {
 		KeyName											=> { type => SCALAR, optional => 1 },
 		SecurityGroup									=> { type => SCALAR | ARRAYREF, optional => 1 },
 		SecurityGroupId									=> { type => SCALAR | ARRAYREF, optional => 1 },
+		AddressingType									=> { type => SCALAR, optional => 1 },
 		AdditionalInfo									=> { type => SCALAR, optional => 1 },
 		UserData										=> { type => SCALAR, optional => 1 },
 		InstanceType									=> { type => SCALAR, optional => 1 },


### PR DESCRIPTION
This parameter was implemented in earlier version (< 0.15) and then marked as deprecated, However the latest EC2 Query API (released the 2012-07-20) still implement it and, in my case, it is very usefull/necessary for my private eucalyptus cloud (without free IP for EBS).
