### PR TITLE
Add asynchronous mode to methods.

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -17,6 +17,9 @@ requires        'Params::Validate'     => 0;
 requires        'XML::Simple'          => 2.18;
 requires        'Moose'                => 0.38;
 requires        'Carp'                 => 0;
+requires        'AnyEvent'             => 0;
+requires        'AnyEvent::HTTP'       => 0;
+requires        'List::Pairwise'       => 0;
 build_requires  'Test::More'           => 0;
 build_requires  'Test::Exception'      => 0;
 


### PR DESCRIPTION
Every method which acts on EC2 can now accept an optional parameter
'CallBack' which is a function to be called when the request is complete.

This callback method will be provided in the first argument with the same
data the function would have provided in it's return value had it been called
without the CallBack argument.

The return value when a CallBack argument is specified will instead be an
AnyEvent::Condvar which can be waited upon using $condvar->recv() to know
when the callback has been completed.
