### PR TITLE
Remove spurious warn present since at least 0.14

### DIFF
--- a/lib/Net/Amazon/EC2.pm
+++ b/lib/Net/Amazon/EC2.pm
@@ -2051,7 +2051,6 @@ sub describe_instance_attribute {
 				push @$block_mappings, $block_device_mapping;
 			}
 
-			warn Dumper($block_mappings);
 			$attribute_response = Net::Amazon::EC2::DescribeInstanceAttributeResponse->new(
 				instance_id				=> $xml->{instanceId},
 				block_device_mapping	=> $block_mappings,


### PR DESCRIPTION
Calls to describe_instance_attribute with Attribute => 'blockDeviceMapping' resulted in a Dump of the data structure regardless of debug status.  Looking at the git log this has been present since at least the 0.14 import to git.
