### PR TITLE
Add support for VolumeType parameter to run_instances()

### DIFF
--- a/lib/Net/Amazon/EC2.pm
+++ b/lib/Net/Amazon/EC2.pm
@@ -62,7 +62,7 @@ use Net::Amazon::EC2::EbsBlockDevice;
 use Net::Amazon::EC2::TagSet;
 use Net::Amazon::EC2::DescribeTags;
 
-$VERSION = '0.24';
+$VERSION = '0.24_01';
 
 =head1 NAME
 


### PR DESCRIPTION
We can now have SSD root devices, by specifying "gp2" as for the BlockDeviceMapping.n.Ebs.VolumeType parameter to run_instances():

http://docs.aws.amazon.com/AWSEC2/latest/APIReference/ApiReference-query-RunInstances.html

This commit adds the ability to send that parameter via Net::Amazon::EC2
