### PR TITLE
Added egress rules to describe_security_groups.

### DIFF
--- a/lib/Net/Amazon/EC2/SecurityGroup.pm
+++ b/lib/Net/Amazon/EC2/SecurityGroup.pm
@@ -21,23 +21,37 @@ The AWS Access Key ID of the owner of the security group.
 
 The name of the security group.
 
+=item group_id (required)
+
+The id of the security group.
+
 =item group_description (required)
 
 The description of the security group.
 
 =item ip_permissions (optional)
 
-An array ref of Net::Amazon::EC2::IpPermission objects.
+An array ref of Net::Amazon::EC2::IpPermission objects for ingress.
 
+=item ip_permissions_egress (optional)
+
+An array ref of Net::Amazon::EC2::IpPermission objects for egress.
 =cut
 
 has 'owner_id'          => ( is => 'ro', isa => 'Str', required => 1 );
 has 'group_name'        => ( is => 'ro', isa => 'Str', required => 1 );
+has 'group_id'          => ( is => 'ro', isa => 'Str', required => 1 );
 has 'group_description' => ( is => 'ro', isa => 'Str', required => 1 );
 has 'ip_permissions'    => ( 
     is          => 'ro', 
     isa         => 'Maybe[ArrayRef[Net::Amazon::EC2::IpPermission]]',
     predicate   => 'has_ip_permissions',
+    default		=> sub { [ ] },
+);
+has 'ip_permissions_egress' => ( 
+    is          => 'ro', 
+    isa         => 'Maybe[ArrayRef[Net::Amazon::EC2::IpPermission]]',
+    predicate   => 'has_ip_permissions_egress',
     default		=> sub { [ ] },
 );
 


### PR DESCRIPTION
I updated describe_security_groups to return egress rules under ip_permissions_egress for VPC security groups. Ingress rules for EC2-classic and VPC security groups are exactly the same so this should not break any code.
