### PR TITLE
Fixing describe_instance_status call to fetch all the status responses

### DIFF
--- a/lib/Net/Amazon/EC2.pm
+++ b/lib/Net/Amazon/EC2.pm
@@ -2112,6 +2112,7 @@ sub describe_instance_status {
         }
 
         if ( grep { defined && length } $xml->{nextToken} ) {
+            $token = $xml->{nextToken};
             while(1) {
                 $args{NextToken} = $token;
                 $self->_build_filters( \%args );

--- a/lib/Net/Amazon/EC2.pm
+++ b/lib/Net/Amazon/EC2.pm
@@ -2082,6 +2082,8 @@ sub describe_instance_status {
         {
             InstanceId => { type => SCALAR | ARRAYREF, optional => 1 },
             Filter     => { type => ARRAYREF,          optional => 1 },
+            MaxResults => { type => SCALAR, optional => 1 },
+            NextToken  => { type => SCALAR, optional => 1 },
         }
     );
 


### PR DESCRIPTION
When I first created this, I didn't realize that a nextToken was being passed and needed to be looped over as well. Most people wouldn't see this issue, unless they happen to have more than 1K worth of instances.

Now the code will call in and fetch all of the instance statuses and return them just like before.