### PR TITLE
Support v4 signatures

### DIFF
--- a/lib/Net/Amazon/EC2.pm
+++ b/lib/Net/Amazon/EC2.pm
@@ -339,7 +339,7 @@ sub _hashit {
 sub _sign_v4 {
 	my $self             = shift;
 	my %args             = @_;
-	my $algorithm        = 'AWS-HMAC-SHA256';
+	my $algorithm        = 'AWS4-HMAC-SHA256';
 	my $service          = 'ec2';
 	my @now              = gmtime();
 	my $amz_date         = strftime("%Y%m%dT%H%M%SZ", @now);

--- a/lib/Net/Amazon/EC2.pm
+++ b/lib/Net/Amazon/EC2.pm
@@ -7,13 +7,14 @@ use vars qw($VERSION);
 use XML::Simple;
 use LWP::UserAgent;
 use LWP::Protocol::https;
-use Digest::SHA qw(hmac_sha256);
+use Digest::SHA qw(hmac_sha256 hmac_sha256_hex sha256_hex);
 use URI;
-use MIME::Base64 qw(encode_base64 decode_base64);
+use MIME::Base64 qw(decode_base64);
 use POSIX qw(strftime);
 use Params::Validate qw(validate SCALAR ARRAYREF HASHREF);
 use Data::Dumper qw(Dumper);
 use URI::Escape qw(uri_escape_utf8);
+use Encode qw(encode_utf8);
 use Carp;
 
 use Net::Amazon::EC2::DescribeImagesResponse;
@@ -168,161 +169,250 @@ If you want/need the old behavior, set this attribute to a true value.
 
 =cut
 
-has 'AWSAccessKeyId'	=> ( is => 'ro',
-			     isa => 'Str',
-			     required => 1,
-			     lazy => 1,
-			     default => sub {
-				 if (defined($_[0]->temp_creds)) {
-				     return $_[0]->temp_creds->{'AccessKeyId'};
-				 } else {
-				     return undef;
-				 }
-			     }
+has 'AWSAccessKeyId' => (
+	is => 'ro',
+	isa => 'Str',
+	required => 1,
+	lazy => 1,
+	default => sub {
+		if (defined($_[0]->temp_creds)) {
+			return $_[0]->temp_creds->{'AccessKeyId'};
+		} else {
+			return undef;
+		}
+	}
 );
-has 'SecretAccessKey'	=> ( is => 'ro',
-			     isa => 'Str',
-			     required => 1,
-			     lazy => 1,
-			     default => sub {
-				 if (defined($_[0]->temp_creds)) {
-				     return $_[0]->temp_creds->{'SecretAccessKey'};
-				 } else {
-				     return undef;
-				 }
-			     }
+has 'SecretAccessKey' => ( 
+	is => 'ro',
+	isa => 'Str',
+	required => 1,
+	lazy => 1,
+	default => sub {
+		if (defined($_[0]->temp_creds)) {
+			return $_[0]->temp_creds->{'SecretAccessKey'};
+		} else {
+			return undef;
+		}
+	}
 );
-has 'SecurityToken'	=> ( is => 'ro',
-			     isa => 'Str',
-			     required => 0,
-			     lazy => 1,
-			     predicate => 'has_SecurityToken',
-			     default => sub {
-				 if (defined($_[0]->temp_creds)) {
-				     return $_[0]->temp_creds->{'Token'};
-				 } else {
-				     return undef;
-				 }
-			     }
+has 'SecurityToken' => ( 
+	is => 'ro',
+	isa => 'Str',
+	required => 0,
+	lazy => 1,
+	predicate => 'has_SecurityToken',
+	default => sub {
+		if (defined($_[0]->temp_creds)) {
+			return $_[0]->temp_creds->{'Token'};
+		} else {
+			return undef;
+		}
+	}
 );
-has 'debug'				=> ( is => 'ro', isa => 'Str', required => 0, default => 0 );
-has 'signature_version'	=> ( is => 'ro', isa => 'Int', required => 1, default => 2 );
-has 'version'			=> ( is => 'ro', isa => 'Str', required => 1, default => '2014-06-15' );
-has 'region'			=> ( is => 'ro', isa => 'Str', required => 1, default => 'us-east-1' );
-has 'ssl'				=> ( is => 'ro', isa => 'Bool', required => 1, default => 1 );
+has 'debug'             => ( is => 'ro', isa => 'Str', required => 0, default => 0 );
+has 'signature_version' => ( is => 'ro', isa => 'Int', required => 1, default => 2 );
+has 'version'           => ( is => 'ro', isa => 'Str', required => 1, default => '2014-06-15' );
+has 'region'            => ( is => 'ro', isa => 'Str', required => 1, default => 'us-east-1' );
+has 'ssl'               => ( is => 'ro', isa => 'Bool', required => 1, default => 1 );
 has 'return_errors'     => ( is => 'ro', isa => 'Bool', default => 0 );
-has 'base_url'			=> ( 
-	is			=> 'ro', 
-	isa			=> 'Str', 
-	required	=> 1,
-	lazy		=> 1,
-	default		=> sub {
+has 'base_url'          => (
+	is       => 'ro',
+	isa      => 'Str',
+	required => 1,
+	lazy     => 1,
+	default  => sub {
 		return 'http' . ($_[0]->ssl ? 's' : '') . '://ec2.' . $_[0]->region . '.amazonaws.com';
 	}
 );
-has 'temp_creds'       => ( is => 'ro',
-			     lazy => 1,
-			     default => sub {
-				 my $ret;
-				 $ret = $_[0]->_fetch_iam_security_credentials();
-			     },
-			     predicate => 'has_temp_creds'
+has 'temp_creds' => (
+	is      => 'ro',
+	lazy    => 1,
+	default => sub {
+		my $ret;
+		$ret = $_[0]->_fetch_iam_security_credentials();
+	},
+	predicate => 'has_temp_creds'
 );
 
-
 sub timestamp {
-    return strftime("%Y-%m-%dT%H:%M:%SZ",gmtime);
+	return strftime("%Y-%m-%dT%H:%M:%SZ",gmtime);
 }
 
 sub _fetch_iam_security_credentials {
-    my $self = shift;
-    my $retval = {};
+	my $self = shift;
+	my $retval = {};
 
-    my $ua = LWP::UserAgent->new();
-    # Fail quickly if this is not running on an EC2 instance
-    $ua->timeout(2);
+	my $ua = LWP::UserAgent->new();
+	# Fail quickly if this is not running on an EC2 instance
+	$ua->timeout(2);
 
-    my $url = 'http://169.254.169.254/latest/meta-data/iam/security-credentials/';
-    
-    $self->_debug("Attempting to fetch instance credentials");
+	my $url = 'http://169.254.169.254/latest/meta-data/iam/security-credentials/';
+	$self->_debug("Attempting to fetch instance credentials");
 
-    my $res = $ua->get($url);
-    if ($res->code == 200) {
-	# Assumes the first profile is the only profile
-	my $profile = (split /\n/, $res->content())[0];
-
-	$res = $ua->get($url . $profile);
-
+	my $res = $ua->get($url);
 	if ($res->code == 200) {
-	    $retval->{'Profile'} = $profile;
-	    foreach (split /\n/, $res->content()) {
-		return undef if /Code/ && !/Success/;
-		if (m/.*"([^"]+)"\s+:\s+"([^"]+)",/) {
-		    $retval->{$1} = $2;
-		}
-	    }
+		# Assumes the first profile is the only profile
+		my $profile = (split /\n/, $res->content())[0];
 
-	    return $retval if (keys %{$retval});
+		$res = $ua->get($url . $profile);
+
+		if ($res->code == 200) {
+			$retval->{'Profile'} = $profile;
+			foreach (split /\n/, $res->content()) {
+				return undef if /Code/ && !/Success/;
+				if (m/.*"([^"]+)"\s+:\s+"([^"]+)",/) {
+					$retval->{$1} = $2;
+				}
+			}
+			return $retval if (keys %{$retval});
+		}
 	}
-	 
-    }
-   
-    return undef;
+	return undef;
 }
 
 sub _sign {
-	my $self						= shift;
-	my %args						= @_;
-	my $action						= delete $args{Action};
-	my %sign_hash					= %args;
-	my $timestamp					= $self->timestamp;
+	my $self = shift;
 
-	$sign_hash{AWSAccessKeyId}		= $self->AWSAccessKeyId;
-	$sign_hash{Action}				= $action;
-	$sign_hash{Timestamp}			= $timestamp;
-	$sign_hash{Version}				= $self->version;
-	$sign_hash{SignatureVersion}	= $self->signature_version;
-    $sign_hash{SignatureMethod}     = "HmacSHA256";
-	if ($self->has_temp_creds || $self->has_SecurityToken) {
-	    $sign_hash{SecurityToken} = $self->SecurityToken;
+	if ( $self->signature_version == 2 ) {
+		$self->_sign_v2(@_);
 	}
+	elsif ( $self->signature_version == 4 ) {
+		$self->_sign_v4(@_);
+	}
+	else {
+		die "I don't know what signature version " . 
+			$self->signature_version . "means.\n";
+	}
+}
 
+sub _sign_v2 {
+	my $self      = shift;
+	my %args      = @_;
+	my $action    = delete $args{Action};
+	my %sign_hash = %args;
+	my $timestamp = $self->timestamp;
+
+	$sign_hash{AWSAccessKeyId}   = $self->AWSAccessKeyId;
+	$sign_hash{Action}           = $action;
+	$sign_hash{Timestamp}        = $timestamp;
+	$sign_hash{Version}          = $self->version;
+	$sign_hash{SignatureVersion} = $self->signature_version;
+	$sign_hash{SignatureMethod}  = "HmacSHA256";
+	if ($self->has_temp_creds || $self->has_SecurityToken) {
+		$sign_hash{SecurityToken} = $self->SecurityToken;
+	}
 
 	my $sign_this = "POST\n";
 	my $uri = URI->new($self->base_url);
 
-    $sign_this .= lc($uri->host) . "\n";
-    $sign_this .= "/\n";
+	$sign_this .= lc($uri->host) . "\n";
+	$sign_this .= "/\n";
 
-    my @signing_elements;
+	my @signing_elements;
 
 	foreach my $key (sort keys %sign_hash) {
 		push @signing_elements, uri_escape_utf8($key)."=".uri_escape_utf8($sign_hash{$key});
 	}
 
-    $sign_this .= join "&", @signing_elements;
+	$sign_this .= join "&", @signing_elements;
 
 	$self->_debug("QUERY TO SIGN: $sign_this");
 	my $encoded = $self->_hashit($self->SecretAccessKey, $sign_this);
 
-    my $content = join "&", @signing_elements, 'Signature=' . uri_escape_utf8($encoded);
+	my $content = join "&", @signing_elements, 'Signature=' . uri_escape_utf8($encoded);
 
-	my $ur	= $uri->as_string();
+	my $ur = $uri->as_string();
 	$self->_debug("GENERATED QUERY URL: $ur");
-	my $ua	= LWP::UserAgent->new();
-    $ua->env_proxy;
-	my $res	= $ua->post($ur, Content => $content);
+	my $ua = LWP::UserAgent->new();
+	$ua->env_proxy;
+	my $res = $ua->post($ur, Content => $content);
+	$self->_handle_response($res);
+}
+
+sub _sign_v4 {
+	my $self             = shift;
+	my %args             = @_;
+	my $algorithm        = 'AWS-HMAC-SHA256';
+	my $service          = 'ec2';
+	my @now              = gmtime();
+	my $amz_date         = strftime("%Y%m%dT%H%M%SZ", @now);
+	my $datestamp        = strftime("%Y%m%d", @now);
+	my $credential_scope = $datestamp . "/" . $self->region . "/" . $service . "/aws4_request"; 
+	my $content_type     = "application/x-www-form-urlencoded";
+	my $signed_headers   = "content-type;host;x-amz-date";
+	# Assemble the content
+	$args{Version}       = $self->version;
+	if ($self->has_temp_creds) {
+		$args{'X-Amz-Security-Token'} = $self->temp_creds->{'Token'};
+	}
+	my @content_elements;
+	foreach my $key (sort keys %args) {
+		push @content_elements, uri_escape_utf8($key)."=".uri_escape_utf8($args{$key});
+	}
+	my $content .= join "&", @content_elements;
+
+	# Step 1: create canonical request string
+	my $uri = URI->new($self->base_url);
+	my $canonical_headers = "content-type:" . $content_type . "\n" .
+				"host:" . lc($uri->host) . "\n" .
+				"x-amz-date:" . $amz_date . "\n";
+
+	my $canonical_request = "POST\n";			# method
+	$canonical_request .= "/\n";				# uri
+	$canonical_request .= "\n";				# query-string
+	$canonical_request .= $canonical_headers . "\n";	# headers
+	$canonical_request .= $signed_headers . "\n";		# signed headers
+	$canonical_request .= sha256_hex($content);		# payload
+
+	# Step 2: create string to sign
+	my $sign_this = $algorithm . "\n";
+	$sign_this .= $amz_date . "\n";
+	$sign_this .= $credential_scope . "\n";
+	$sign_this .= sha256_hex($canonical_request);
+
+	$self->_debug("STRING TO SIGN: $sign_this");
+
+	# Step 3: calculate the signature
+	my $key_date = $self->_hmac(encode_utf8('AWS4' . $self->SecretAccessKey), $datestamp);
+	my $key_region = $self->_hmac($key_date, $self->region);
+	my $key_service = $self->_hmac($key_region, $service);
+	my $signing_key = $self->_hmac($key_service, 'aws4_request');
+
+	my $signature = $self->_hmac($signing_key, encode_utf8($sign_this), 1);
+
+	# send request
+	my $auth_header = $algorithm .
+				' Credential=' . $self->AWSAccessKeyId . '/' . $credential_scope .
+				', SignedHeaders=' . $signed_headers .
+				', Signature=' . $signature;
+
+	my $ur = $uri->as_string();
+	$self->_debug("GENERATED QUERY URL: $ur");
+	my $ua = LWP::UserAgent->new();
+	$ua->env_proxy;
+
+	my $res = $ua->post($ur,
+			"Authorization" => $auth_header,
+			"Content-Type" => $content_type,
+			"X-Amz-Date" => $amz_date,
+			Content => $content);
+
+	$self->_handle_response($res);
+}
+
+sub _handle_response {
+	my ($self, $res) = @_;
 	# We should force <item> elements to be in an array
 	my $xs	= XML::Simple->new(
-        ForceArray => qr/(?:item|Errors)/i, # Always want item elements unpacked to arrays
-        KeyAttr => '',                      # Turn off folding for 'id', 'name', 'key' elements
-        SuppressEmpty => undef,             # Turn empty values into explicit undefs
-    );
+	ForceArray => qr/(?:item|Errors)/i, # Always want item elements unpacked to arrays
+	KeyAttr => '',                      # Turn off folding for 'id', 'name', 'key' elements
+	SuppressEmpty => undef,             # Turn empty values into explicit undefs
+	);
 	my $xml;
 	
 	# Check the result for connectivity problems, if so throw an error
- 	if ($res->code >= 500) {
- 		my $message = $res->status_line;
+	if ($res->code >= 500) {
+		my $message = $res->status_line;
 		$xml = <<EOXML;
 <xml>
 	<RequestID>N/A</RequestID>
@@ -335,7 +425,7 @@ sub _sign {
 </xml>
 EOXML
 
- 	}
+	}
 	else {
 		$xml = $res->content();
 	}
@@ -393,12 +483,11 @@ sub _debug {
 	}
 }
 
-# HMAC sign the query with the aws secret access key and base64 encodes the result.
-sub _hashit {
-	my $self								= shift;
-	my ($secret_access_key, $query_string)	= @_;
-	
-	return encode_base64(hmac_sha256($query_string, $secret_access_key), '');
+sub _hmac {
+	my $self				= shift;
+	my ($key, $msg, $hex) 	= @_;
+	my $func = $hex ? \&hmac_sha256_hex : \&hmac_sha256;
+	return &$func(encode_utf8($msg), $key);
 }
 
 sub _build_filters {

--- a/t/02_live.t
+++ b/t/02_live.t
@@ -9,7 +9,7 @@ BEGIN {
         plan skip_all => "Set AWS_ACCESS_KEY_ID and SECRET_ACCESS_KEY environment variables to run these _LIVE_ tests (NOTE: they will incur one instance hour of costs from EC2)";
     }
     else {
-        plan tests => 29;
+        plan tests => 31;
         use_ok( 'Net::Amazon::EC2' );
     }
 };
@@ -152,6 +152,21 @@ foreach my $instance (@{$running_instances}) {
     }
 }
 ok($seen_test_instance == 1, "Checking for newly run instance");
+
+my $volume = $ec2->create_volume(
+    Size             => 10,
+    AvailabilityZone => 'us-east-1a',
+    VolumeType       => 'io1',
+    Iops             => 300,
+    Encrypted        => 1
+);
+note explain $volume;
+
+isa_ok($volume, 'Net::Amazon::EC2::Volume');
+
+my $rc = $ec2->delete_volume( VolumeId => $volume->volume_id );
+note explain $rc;
+ok($rc, "successfully deleted volume");
 
 
 # create tags

--- a/t/04_live_v4.t
+++ b/t/04_live_v4.t
@@ -1,0 +1,269 @@
+use strict;
+use blib;
+use Test::More;
+
+use MIME::Base64 qw(encode_base64);
+
+BEGIN { 
+    if (! $ENV{AWS_ACCESS_KEY_ID} || ! $ENV{SECRET_ACCESS_KEY} ) {
+        plan skip_all => "Set AWS_ACCESS_KEY_ID and SECRET_ACCESS_KEY environment variables to run these _LIVE_ tests (NOTE: they will incur one instance hour of costs from EC2)";
+    }
+    else {
+        plan tests => 29;
+        use_ok( 'Net::Amazon::EC2' );
+    }
+};
+
+my $ec2 = eval {
+    Net::Amazon::EC2->new(
+	AWSAccessKeyId    => $ENV{AWS_ACCESS_KEY_ID},
+	SecretAccessKey   => $ENV{SECRET_ACCESS_KEY},
+	ssl               => 1,
+	debug             => 1,
+        signature_version => 4,
+	return_errors     => 1,
+    );
+};
+
+isa_ok($ec2, 'Net::Amazon::EC2');
+
+my $delete_key_result   = $ec2->delete_key_pair(KeyName => "test_keys");
+my $delete_group_result = $ec2->delete_security_group(GroupName => "test_group");
+
+# create_key_pair
+my $key_pair = $ec2->create_key_pair(KeyName => "test_keys");
+isa_ok($key_pair, 'Net::Amazon::EC2::KeyPair');
+is($key_pair->key_name, "test_keys", "Does new key pair come back?");
+
+# describe_key_pairs
+my $key_pairs       = $ec2->describe_key_pairs;
+my $seen_test_key   = 0;
+foreach my $key_pair (@{$key_pairs}) {
+    if ($key_pair->key_name eq "test_keys") {
+        $seen_test_key = 1;
+    }
+}
+ok($seen_test_key == 1, "Checking for created key pair in describe keys");
+
+# For cleanup purposes
+$ec2->delete_security_group(GroupName => "test_group");
+
+# create_security_group
+my $create_result = $ec2->create_security_group(GroupName => "test_group", GroupDescription => "test description");    
+ok($create_result == 1, "Checking for created security group");
+
+# authorize_security_group_ingress
+my $authorize_result = $ec2->authorize_security_group_ingress(GroupName => "test_group", IpProtocol => 'tcp', FromPort => '7003', ToPort => '7003', CidrIp => '10.253.253.253/32');
+ok($authorize_result == 1, "Checking for authorization of rule for security group");
+
+# Add this for RT Bug: #33883
+my $authorize_result_bad = $ec2->authorize_security_group_ingress(GroupName => "test_group_non_existant", IpProtocol => 'tcp', FromPort => '7003', ToPort => '7003', CidrIp => '10.253.253.253/32');
+isa_ok($authorize_result_bad, 'Net::Amazon::EC2::Errors');
+
+# describe_security_groups
+my $security_groups = $ec2->describe_security_groups();
+my $seen_test_group = 0;
+my $seen_test_rule  = 0;
+foreach my $security_group (@{$security_groups}) {
+    if ($security_group->group_name eq "test_group") {
+        $seen_test_group = 1;
+        if ($security_group->ip_permissions->[0]->ip_ranges->[0]->cidr_ip eq '10.253.253.253/32') {
+            $seen_test_rule = 1;
+        }
+    }
+}
+ok($seen_test_group == 1, "Checking for created security group in describe results");
+ok($seen_test_rule == 1, "Checking for created authorized security group rule in describe results");
+
+# revoke_security_group_ingress
+my $revoke_result = $ec2->revoke_security_group_ingress(GroupName => "test_group", IpProtocol => 'tcp', FromPort => '7003', ToPort => '7003', CidrIp => '10.253.253.253/32');
+ok($revoke_result == 1, "Checking for revocation of rule for security group");
+
+my $user_data =<<_EOF;
+I am the very model of a modern Major-General,
+I've information vegetable, animal, and mineral,
+I know the kings of England, and I quote the fights historical
+From Marathon to Waterloo, in order categorical;
+I'm very well acquainted, too, with matters mathematical,
+I understand equations, both the simple and quadratical,
+About binomial theorem I'm teeming with a lot o' news,
+With many cheerful facts about the square of the hypotenuse.
+I'm very good at integral and differential calculus;
+I know the scientific names of beings animalculous:
+In short, in matters vegetable, animal, and mineral,
+I am the very model of a modern Major-General.
+I know our mythic history, King Arthur's and Sir Caradoc's;
+I answer hard acrostics, I've a pretty taste for paradox,
+I quote in elegiacs all the crimes of Heliogabalus,
+In conics I can floor peculiarities parabolous;
+I can tell undoubted Raphaels from Gerard Dows and Zoffanies,
+I know the croaking chorus from The Frogs of Aristophanes!
+Then I can hum a fugue of which I've heard the music's din afore,
+And whistle all the airs from that infernal nonsense Pinafore.
+Then I can write a washing bill in Babylonic cuneiform,
+And tell you ev'ry detail of Caractacus's uniform:
+In short, in matters vegetable, animal, and mineral,
+I am the very model of a modern Major-General.
+In fact, when I know what is meant by "mamelon" and "ravelin",
+When I can tell at sight a Mauser rifle from a Javelin,
+When such affairs as sorties and surprises I'm more wary at,
+And when I know precisely what is meant by "commissariat",
+When I have learnt what progress has been made in modern gunnery,
+When I know more of tactics than a novice in a nunnery—
+In short, when I've a smattering of elemental strategy—
+You'll say a better Major-General has never sat a gee.
+For my military knowledge, though I'm plucky and adventury,
+Has only been brought down to the beginning of the century;
+But still, in matters vegetable, animal, and mineral,
+I am the very model of a modern Major-General.
+_EOF
+
+# run_instances
+my $run_result = $ec2->run_instances(
+        MinCount        => 1, 
+        MaxCount        => 1, 
+        ImageId         => "ami-26b6534f", # ec2-public-images/developer-image.manifest.xml
+        KeyName         => "test_keys", 
+        SecurityGroup   => "test_group",
+        InstanceType    => 'm1.small',
+        UserData        => encode_base64($user_data, ""),
+        EbsOptimized    => 0,
+);
+isa_ok($run_result, 'Net::Amazon::EC2::ReservationInfo');
+ok($run_result->group_set->[0]->group_name eq "test_group", "Checking for running instance");
+my $instance_id = $run_result->instances_set->[0]->instance_id;
+
+# describe_instances
+my $running_instances = $ec2->describe_instances();
+my $seen_test_instance = 0;
+foreach my $instance (@{$running_instances}) {
+    my $instance_set = $instance->instances_set->[0];
+    my $key_name = $instance_set->key_name || '';
+    my $image_id = $instance_set->image_id || '';
+    if ($key_name eq 'test_keys' and $image_id eq 'ami-26b6534f') {
+        $seen_test_instance = 1;
+    }
+}
+ok($seen_test_instance == 1, "Checking for newly run instance");
+
+
+# create tags
+my $create_tags_result = $ec2->create_tags(
+    ResourceId  => $instance_id,
+    Tags        => { 
+                Name => 'hoge',
+        test_tag_key => 'test_tag_value',
+    },
+);
+ok($create_tags_result == 1, "Checking for created tags");
+
+# describe_instances
+$running_instances = $ec2->describe_instances();
+my $test_instance;
+foreach my $instance (@{$running_instances}) {
+    my $instance_set = $instance->instances_set->[0];
+    if ($instance_set->instance_id eq $instance_id) {
+        $test_instance = $instance_set;
+        last;
+    }
+}
+# instance name
+is($test_instance->name, 'hoge', 'Checking for instance name');
+# instance tags
+foreach my $tag (@{$test_instance->tag_set}) {
+    if($tag->key eq 'Name' && $tag->value eq 'hoge') {
+        ok(1, 'Checking for tag (Name=hoge)');
+    }elsif($tag->key eq 'test_tag_key' && $tag->value eq 'test_tag_value') {
+        ok(1, 'Checking for tag (test_tag_key=test_tag_value)');
+    }
+}
+# delete tags
+my $delete_tags_result = $ec2->delete_tags(
+    ResourceId  => $instance_id,
+    'Tag.Key'   => ["Name","test_tag_key"],
+);
+ok($delete_tags_result == 1, "Checking for delete tags");
+
+note("Describe instance status test takes up to 120 seconds to complete. Be patient.");
+my $instance_statuses;
+my $loop_count = 0;
+while ( $loop_count < 40 ) {
+    $instance_statuses = $ec2->describe_instance_status(); 
+    if ( not defined $instance_statuses->[0] ) {
+        sleep 5;
+        $loop_count++;
+        next;
+    }
+    else {
+        last;
+    }
+}
+isa_ok($instance_statuses->[0], 'Net::Amazon::EC2::InstanceStatuses');
+
+# terminate_instances
+my $terminate_result = $ec2->terminate_instances(InstanceId => $instance_id);
+is($terminate_result->[0]->instance_id, $instance_id, "Checking to see if instance was terminated successfully");
+
+# delete_key_pair
+$delete_key_result = $ec2->delete_key_pair(KeyName => "test_keys");
+ok($delete_key_result == 1, "Deleting key pair");
+
+my $availability_zones = $ec2->describe_availability_zones();
+my $seen_availability_zone = 0;
+foreach my $availability_zone (@{$availability_zones}) {
+	if ($availability_zone->zone_name eq 'us-east-1a') {
+		$seen_availability_zone = 1;
+	}
+}
+ok($seen_availability_zone == 1, "Describing availability zones");
+
+my $regions = $ec2->describe_regions();
+my $seen_region = 0;
+foreach my $region (@{$regions}) {
+	if ($region->region_name eq 'us-east-1') {
+		$seen_region = 1;
+	}
+}
+ok($seen_region == 1, "Describing regions");
+
+my $reserved_instance_offerings = $ec2->describe_reserved_instances_offerings();
+my $seen_offering = 0;
+foreach my $offering (@{$reserved_instance_offerings}) {
+	if ($offering->product_description eq 'Linux/UNIX') {
+		$seen_offering = 1;
+	}
+}
+ok($seen_offering == 1, "Describing Reserved Instances Offerings");
+
+note("Delete security group test takes up to 120 seconds to complete. Be patient.");
+# delete_security_group
+$loop_count = 0;
+while ( $loop_count < 20 ) {
+    $delete_group_result = $ec2->delete_security_group(GroupName => "test_group");
+    if ( ref($delete_group_result) =~ /Error/ ) {
+        # If we get an error, loop until we don't
+        sleep 5;
+        $loop_count++;
+        next;
+    }
+    else {
+        last;
+    }
+}
+ok($delete_group_result == 1, "Deleting security group");
+
+# create_volume
+my $volume = $ec2->create_volume(
+        Size             => 1,
+        AvailabilityZone => 'us-east-1a',
+        Encrypted        => 'true',
+);
+isa_ok($volume, 'Net::Amazon::EC2::Volume');
+
+my $describe_volume = $ec2->describe_volumes( { VolumeId => $volume->volume_id } );
+ok($describe_volume->[0]->volume_id, $volume->volume_id);
+
+my $delete_volume = $ec2->delete_volume( { VolumeId => $volume->volume_id } );
+ok($delete_volume == 1, "Deleting volume");
+
+# THE REST OF THE METHODS ARE SKIPPED FOR NOW SINCE IT WOULD REQUIRE A DECENT AMOUNT OF TIME IN BETWEEN OPERATIONS TO COMPLETE

--- a/t/04_live_v4.t
+++ b/t/04_live_v4.t
@@ -2,14 +2,12 @@ use strict;
 use blib;
 use Test::More;
 
-use MIME::Base64 qw(encode_base64);
-
 BEGIN { 
     if (! $ENV{AWS_ACCESS_KEY_ID} || ! $ENV{SECRET_ACCESS_KEY} ) {
         plan skip_all => "Set AWS_ACCESS_KEY_ID and SECRET_ACCESS_KEY environment variables to run these _LIVE_ tests (NOTE: they will incur one instance hour of costs from EC2)";
     }
     else {
-        plan tests => 29;
+        plan tests => 5;
         use_ok( 'Net::Amazon::EC2' );
     }
 };
@@ -18,8 +16,9 @@ my $ec2 = eval {
     Net::Amazon::EC2->new(
 	AWSAccessKeyId    => $ENV{AWS_ACCESS_KEY_ID},
 	SecretAccessKey   => $ENV{SECRET_ACCESS_KEY},
+        region            => 'eu-central-1',
 	ssl               => 1,
-	debug             => 1,
+        #debug             => 1,
         signature_version => 4,
 	return_errors     => 1,
     );
@@ -27,191 +26,10 @@ my $ec2 = eval {
 
 isa_ok($ec2, 'Net::Amazon::EC2');
 
-my $delete_key_result   = $ec2->delete_key_pair(KeyName => "test_keys");
-my $delete_group_result = $ec2->delete_security_group(GroupName => "test_group");
-
-# create_key_pair
-my $key_pair = $ec2->create_key_pair(KeyName => "test_keys");
-isa_ok($key_pair, 'Net::Amazon::EC2::KeyPair');
-is($key_pair->key_name, "test_keys", "Does new key pair come back?");
-
-# describe_key_pairs
-my $key_pairs       = $ec2->describe_key_pairs;
-my $seen_test_key   = 0;
-foreach my $key_pair (@{$key_pairs}) {
-    if ($key_pair->key_name eq "test_keys") {
-        $seen_test_key = 1;
-    }
-}
-ok($seen_test_key == 1, "Checking for created key pair in describe keys");
-
-# For cleanup purposes
-$ec2->delete_security_group(GroupName => "test_group");
-
-# create_security_group
-my $create_result = $ec2->create_security_group(GroupName => "test_group", GroupDescription => "test description");    
-ok($create_result == 1, "Checking for created security group");
-
-# authorize_security_group_ingress
-my $authorize_result = $ec2->authorize_security_group_ingress(GroupName => "test_group", IpProtocol => 'tcp', FromPort => '7003', ToPort => '7003', CidrIp => '10.253.253.253/32');
-ok($authorize_result == 1, "Checking for authorization of rule for security group");
-
-# Add this for RT Bug: #33883
-my $authorize_result_bad = $ec2->authorize_security_group_ingress(GroupName => "test_group_non_existant", IpProtocol => 'tcp', FromPort => '7003', ToPort => '7003', CidrIp => '10.253.253.253/32');
-isa_ok($authorize_result_bad, 'Net::Amazon::EC2::Errors');
-
-# describe_security_groups
-my $security_groups = $ec2->describe_security_groups();
-my $seen_test_group = 0;
-my $seen_test_rule  = 0;
-foreach my $security_group (@{$security_groups}) {
-    if ($security_group->group_name eq "test_group") {
-        $seen_test_group = 1;
-        if ($security_group->ip_permissions->[0]->ip_ranges->[0]->cidr_ip eq '10.253.253.253/32') {
-            $seen_test_rule = 1;
-        }
-    }
-}
-ok($seen_test_group == 1, "Checking for created security group in describe results");
-ok($seen_test_rule == 1, "Checking for created authorized security group rule in describe results");
-
-# revoke_security_group_ingress
-my $revoke_result = $ec2->revoke_security_group_ingress(GroupName => "test_group", IpProtocol => 'tcp', FromPort => '7003', ToPort => '7003', CidrIp => '10.253.253.253/32');
-ok($revoke_result == 1, "Checking for revocation of rule for security group");
-
-my $user_data =<<_EOF;
-I am the very model of a modern Major-General,
-I've information vegetable, animal, and mineral,
-I know the kings of England, and I quote the fights historical
-From Marathon to Waterloo, in order categorical;
-I'm very well acquainted, too, with matters mathematical,
-I understand equations, both the simple and quadratical,
-About binomial theorem I'm teeming with a lot o' news,
-With many cheerful facts about the square of the hypotenuse.
-I'm very good at integral and differential calculus;
-I know the scientific names of beings animalculous:
-In short, in matters vegetable, animal, and mineral,
-I am the very model of a modern Major-General.
-I know our mythic history, King Arthur's and Sir Caradoc's;
-I answer hard acrostics, I've a pretty taste for paradox,
-I quote in elegiacs all the crimes of Heliogabalus,
-In conics I can floor peculiarities parabolous;
-I can tell undoubted Raphaels from Gerard Dows and Zoffanies,
-I know the croaking chorus from The Frogs of Aristophanes!
-Then I can hum a fugue of which I've heard the music's din afore,
-And whistle all the airs from that infernal nonsense Pinafore.
-Then I can write a washing bill in Babylonic cuneiform,
-And tell you ev'ry detail of Caractacus's uniform:
-In short, in matters vegetable, animal, and mineral,
-I am the very model of a modern Major-General.
-In fact, when I know what is meant by "mamelon" and "ravelin",
-When I can tell at sight a Mauser rifle from a Javelin,
-When such affairs as sorties and surprises I'm more wary at,
-And when I know precisely what is meant by "commissariat",
-When I have learnt what progress has been made in modern gunnery,
-When I know more of tactics than a novice in a nunnery—
-In short, when I've a smattering of elemental strategy—
-You'll say a better Major-General has never sat a gee.
-For my military knowledge, though I'm plucky and adventury,
-Has only been brought down to the beginning of the century;
-But still, in matters vegetable, animal, and mineral,
-I am the very model of a modern Major-General.
-_EOF
-
-# run_instances
-my $run_result = $ec2->run_instances(
-        MinCount        => 1, 
-        MaxCount        => 1, 
-        ImageId         => "ami-26b6534f", # ec2-public-images/developer-image.manifest.xml
-        KeyName         => "test_keys", 
-        SecurityGroup   => "test_group",
-        InstanceType    => 'm1.small',
-        UserData        => encode_base64($user_data, ""),
-        EbsOptimized    => 0,
-);
-isa_ok($run_result, 'Net::Amazon::EC2::ReservationInfo');
-ok($run_result->group_set->[0]->group_name eq "test_group", "Checking for running instance");
-my $instance_id = $run_result->instances_set->[0]->instance_id;
-
-# describe_instances
-my $running_instances = $ec2->describe_instances();
-my $seen_test_instance = 0;
-foreach my $instance (@{$running_instances}) {
-    my $instance_set = $instance->instances_set->[0];
-    my $key_name = $instance_set->key_name || '';
-    my $image_id = $instance_set->image_id || '';
-    if ($key_name eq 'test_keys' and $image_id eq 'ami-26b6534f') {
-        $seen_test_instance = 1;
-    }
-}
-ok($seen_test_instance == 1, "Checking for newly run instance");
-
-
-# create tags
-my $create_tags_result = $ec2->create_tags(
-    ResourceId  => $instance_id,
-    Tags        => { 
-                Name => 'hoge',
-        test_tag_key => 'test_tag_value',
-    },
-);
-ok($create_tags_result == 1, "Checking for created tags");
-
-# describe_instances
-$running_instances = $ec2->describe_instances();
-my $test_instance;
-foreach my $instance (@{$running_instances}) {
-    my $instance_set = $instance->instances_set->[0];
-    if ($instance_set->instance_id eq $instance_id) {
-        $test_instance = $instance_set;
-        last;
-    }
-}
-# instance name
-is($test_instance->name, 'hoge', 'Checking for instance name');
-# instance tags
-foreach my $tag (@{$test_instance->tag_set}) {
-    if($tag->key eq 'Name' && $tag->value eq 'hoge') {
-        ok(1, 'Checking for tag (Name=hoge)');
-    }elsif($tag->key eq 'test_tag_key' && $tag->value eq 'test_tag_value') {
-        ok(1, 'Checking for tag (test_tag_key=test_tag_value)');
-    }
-}
-# delete tags
-my $delete_tags_result = $ec2->delete_tags(
-    ResourceId  => $instance_id,
-    'Tag.Key'   => ["Name","test_tag_key"],
-);
-ok($delete_tags_result == 1, "Checking for delete tags");
-
-note("Describe instance status test takes up to 120 seconds to complete. Be patient.");
-my $instance_statuses;
-my $loop_count = 0;
-while ( $loop_count < 40 ) {
-    $instance_statuses = $ec2->describe_instance_status(); 
-    if ( not defined $instance_statuses->[0] ) {
-        sleep 5;
-        $loop_count++;
-        next;
-    }
-    else {
-        last;
-    }
-}
-isa_ok($instance_statuses->[0], 'Net::Amazon::EC2::InstanceStatuses');
-
-# terminate_instances
-my $terminate_result = $ec2->terminate_instances(InstanceId => $instance_id);
-is($terminate_result->[0]->instance_id, $instance_id, "Checking to see if instance was terminated successfully");
-
-# delete_key_pair
-$delete_key_result = $ec2->delete_key_pair(KeyName => "test_keys");
-ok($delete_key_result == 1, "Deleting key pair");
-
 my $availability_zones = $ec2->describe_availability_zones();
 my $seen_availability_zone = 0;
 foreach my $availability_zone (@{$availability_zones}) {
-	if ($availability_zone->zone_name eq 'us-east-1a') {
+	if ($availability_zone->zone_name eq 'eu-central-1a') {
 		$seen_availability_zone = 1;
 	}
 }
@@ -234,36 +52,3 @@ foreach my $offering (@{$reserved_instance_offerings}) {
 	}
 }
 ok($seen_offering == 1, "Describing Reserved Instances Offerings");
-
-note("Delete security group test takes up to 120 seconds to complete. Be patient.");
-# delete_security_group
-$loop_count = 0;
-while ( $loop_count < 20 ) {
-    $delete_group_result = $ec2->delete_security_group(GroupName => "test_group");
-    if ( ref($delete_group_result) =~ /Error/ ) {
-        # If we get an error, loop until we don't
-        sleep 5;
-        $loop_count++;
-        next;
-    }
-    else {
-        last;
-    }
-}
-ok($delete_group_result == 1, "Deleting security group");
-
-# create_volume
-my $volume = $ec2->create_volume(
-        Size             => 1,
-        AvailabilityZone => 'us-east-1a',
-        Encrypted        => 'true',
-);
-isa_ok($volume, 'Net::Amazon::EC2::Volume');
-
-my $describe_volume = $ec2->describe_volumes( { VolumeId => $volume->volume_id } );
-ok($describe_volume->[0]->volume_id, $volume->volume_id);
-
-my $delete_volume = $ec2->delete_volume( { VolumeId => $volume->volume_id } );
-ok($delete_volume == 1, "Deleting volume");
-
-# THE REST OF THE METHODS ARE SKIPPED FOR NOW SINCE IT WOULD REQUIRE A DECENT AMOUNT OF TIME IN BETWEEN OPERATIONS TO COMPLETE


### PR DESCRIPTION
The bulk of this code comes from [RT#99779](https://rt.cpan.org/Ticket/Display.html?id=99779) - but reworked to support both v2 and v4 signatures. For now the default is v2 signatures but I could see that changing in a forthcoming release.

The diff is a bit noisy because of a bunch of whitespace formatting changes.