### PR TITLE
[FIX] no stateReason for empty hash

### DIFF
--- a/lib/Net/Amazon/EC2.pm
+++ b/lib/Net/Amazon/EC2.pm
@@ -2091,7 +2091,7 @@ sub describe_instances {
 					}
 				}
 
-				if ( grep { defined && length } $instance_elem->{stateReason} ) {
+				if ( grep { defined && length && $_->{code} && $_->{message} } $instance_elem->{stateReason} ) {
 					$state_reason = Net::Amazon::EC2::StateReason->new(
 						code	=> $instance_elem->{stateReason}{code},
 						message	=> $instance_elem->{stateReason}{message},


### PR DESCRIPTION
It has happened for me that describe_instances received empty hashes for
a stateReason, i.e. both code and message where undef. In this case an
exception is thrown because undef violates the type constraints for the
StateReason objects. If an empty hash is given, we now act like no
stateReason was given at all.